### PR TITLE
refactor: use RepoInfo struct instead of separate owner/repo params

### DIFF
--- a/src/local/consensus/git.rs
+++ b/src/local/consensus/git.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use v_utils::prelude::*;
 
 use super::super::Local;
+use crate::RepoInfo;
 
 /// Check if git is initialized in the issues directory.
 pub fn is_git_initialized() -> bool {
@@ -24,7 +25,7 @@ pub fn is_git_initialized() -> bool {
 }
 
 /// Stage and commit changes for an issue file.
-pub fn commit_issue_changes(owner: &str, repo: &str, issue_number: u64) -> Result<()> {
+pub fn commit_issue_changes(repo_info: RepoInfo, issue_number: u64) -> Result<()> {
 	let data_dir = Local::issues_dir();
 	let data_dir_str = data_dir.to_str().ok_or_else(|| eyre!("Invalid data directory path"))?;
 
@@ -42,7 +43,7 @@ pub fn commit_issue_changes(owner: &str, repo: &str, issue_number: u64) -> Resul
 	}
 
 	// Commit with provided or default message
-	let commit_msg = format!("sync: {owner}/{repo}#{issue_number}");
+	let commit_msg = format!("sync: {}/{}#{issue_number}", repo_info.owner(), repo_info.repo());
 	Command::new("git").args(["-C", data_dir_str, "commit", "-m", &commit_msg]).output()?;
 
 	Ok(())

--- a/src/open_interactions/command.rs
+++ b/src/open_interactions/command.rs
@@ -168,9 +168,10 @@ pub async fn open_command(settings: &LiveSettings, args: OpenArgs, offline: bool
 		}
 
 		let (owner, repo, issue_number) = github::parse_github_issue_url(input)?;
+		let repo_info = tedi::RepoInfo::new(&owner, &repo);
 
 		// Check if we already have this issue locally
-		let existing_path = Local::find_issue_file(&owner, &repo, Some(issue_number), "", &[]);
+		let existing_path = Local::find_issue_file(repo_info, Some(issue_number), "", &[]);
 
 		let issue = if let Some(path) = existing_path {
 			// File exists locally - proceed with unified sync (like --pull)
@@ -194,7 +195,7 @@ pub async fn open_command(settings: &LiveSettings, args: OpenArgs, offline: bool
 
 			// Commit the fetched state as the consensus baseline
 			use super::consensus::commit_issue_changes;
-			commit_issue_changes(&owner, &repo, issue_number)?;
+			commit_issue_changes(repo_info, issue_number)?;
 
 			issue
 		};

--- a/src/open_interactions/merge.rs
+++ b/src/open_interactions/merge.rs
@@ -197,14 +197,14 @@ fn merge_children(self_children: &mut Vec<Issue>, other_children: Vec<Issue>, fo
 
 #[cfg(test)]
 mod tests {
-	use tedi::{IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps};
+	use tedi::{IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps, RepoInfo};
 
 	use super::*;
 
 	fn make_linked_issue(title: &str, number: u64, timestamps: IssueTimestamps) -> Issue {
 		let url = format!("https://github.com/test/repo/issues/{number}");
 		let link = IssueLink::parse(&url).unwrap();
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(RepoInfo::new("test", "repo"));
 		let identity = IssueIdentity::linked(parent_index, "user".to_string(), link, timestamps);
 		Issue {
 			identity,
@@ -220,7 +220,7 @@ mod tests {
 	}
 
 	fn make_pending_issue(title: &str) -> Issue {
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(RepoInfo::new("test", "repo"));
 		let identity = IssueIdentity::pending(parent_index);
 		Issue {
 			identity,
@@ -237,7 +237,7 @@ mod tests {
 
 	#[test]
 	fn test_merge_virtual_error() {
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(RepoInfo::new("test", "repo"));
 		// Create a virtual issue (local-only, never synced to Github)
 		let mut virtual_issue = Issue {
 			identity: IssueIdentity::virtual_issue(parent_index),

--- a/src/open_interactions/remote/mod.rs
+++ b/src/open_interactions/remote/mod.rs
@@ -144,7 +144,7 @@ impl RemoteSource {
 		};
 		// Build parent_index with all parent numbers as GitId selectors
 		let selectors: Vec<IssueSelector> = lineage.iter().map(|&n| IssueSelector::GitId(n)).collect();
-		Ok(IssueIndex::with_index(repo_info.owner(), repo_info.repo(), selectors))
+		Ok(IssueIndex::with_index(repo_info, selectors))
 	}
 
 	/// Create a child source for a sub-issue.

--- a/src/open_interactions/touch.rs
+++ b/src/open_interactions/touch.rs
@@ -84,6 +84,7 @@ pub fn parse_touch_path(user_input: &str) -> Result<TouchPathResult> {
 		}
 	};
 	actual_path = actual_path.join(&repo);
+	let repo_info = tedi::RepoInfo::new(&owner, &repo);
 
 	// Match remaining segments (issue and optional sub-issues)
 	let mut matched_lineage: Vec<String> = Vec::new();
@@ -103,7 +104,7 @@ pub fn parse_touch_path(user_input: &str) -> Result<TouchPathResult> {
 					index.push(IssueSelector::GitId(parent_num));
 					let child_title = strip_md_extension(lineage_rgxs[i + 1]);
 					index.push(IssueSelector::title(child_title));
-					return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(&owner, &repo, index))));
+					return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(repo_info, index))));
 				}
 
 				matched_lineage.push(matched);
@@ -113,7 +114,7 @@ pub fn parse_touch_path(user_input: &str) -> Result<TouchPathResult> {
 				// No match - this is a create request
 				let mut index: Vec<IssueSelector> = matched_lineage.iter().filter_map(|s| extract_issue_number(s).map(IssueSelector::GitId)).collect();
 				index.push(IssueSelector::title(pattern));
-				return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(&owner, &repo, index))));
+				return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(repo_info, index))));
 			}
 			MatchOrNone::Ambiguous(matches) => {
 				let desc = if is_last { "issue" } else { "parent issue" };

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -188,10 +188,10 @@ pub trait Sink<S> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{BlockerSequence, CloseState, Events, IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps};
+	use crate::{BlockerSequence, CloseState, Events, IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps, RepoInfo};
 
 	fn make_issue(title: &str, number: Option<u64>) -> Issue {
-		let parent_index = IssueIndex::repo_only("o", "r");
+		let parent_index = IssueIndex::repo_only(RepoInfo::new("o", "r"));
 		let identity = match number {
 			Some(n) => {
 				let link = IssueLink::parse(&format!("https://github.com/o/r/issues/{n}")).unwrap();

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -151,8 +151,8 @@ impl TestContext {
 	}
 
 	/// Create an OpenUrlBuilder for running the `open` command with a Github URL.
-	pub fn open_url(&self, owner: &str, repo: &str, number: u64) -> OpenUrlBuilder<'_> {
-		let url = format!("https://github.com/{owner}/{repo}/issues/{number}");
+	pub fn open_url(&self, repo_info: tedi::RepoInfo, number: u64) -> OpenUrlBuilder<'_> {
+		let url = format!("https://github.com/{}/{}/issues/{number}", repo_info.owner(), repo_info.repo());
 		OpenUrlBuilder::with_url(self, url)
 	}
 

--- a/tests/integration/file_naming.rs
+++ b/tests/integration/file_naming.rs
@@ -7,9 +7,13 @@
 //! Also tests that old file placements are automatically cleaned up when the
 //! format changes (e.g., when an issue gains sub-issues).
 
-use tedi::Issue;
+use tedi::{Issue, RepoInfo};
 
 use crate::common::{TestContext, git::GitExt};
+
+fn repo() -> RepoInfo {
+	RepoInfo::new("o", "r")
+}
 
 fn parse(content: &str) -> Issue {
 	Issue::deserialize_virtual(content).expect("failed to parse test issue")
@@ -31,10 +35,10 @@ fn test_flat_format_preserved_when_no_sub_issues() {
 	assert!(status.success(), "Should succeed. stderr: {stderr}");
 
 	// Flat file should still exist
-	assert!(ctx.flat_issue_path("o", "r", 1, "Parent Issue").exists(), "Flat format file should still exist");
+	assert!(ctx.flat_issue_path(repo(), 1, "Parent Issue").exists(), "Flat format file should still exist");
 
 	// Directory format should NOT exist
-	assert!(!ctx.dir_issue_path("o", "r", 1, "Parent Issue").exists(), "Directory format should not be created");
+	assert!(!ctx.dir_issue_path(repo(), 1, "Parent Issue").exists(), "Directory format should not be created");
 }
 
 #[test]
@@ -65,10 +69,10 @@ fn test_old_flat_file_removed_when_sub_issues_appear() {
 	assert!(status.success(), "Should succeed. stderr: {stderr}");
 
 	// Old flat file should be removed
-	assert!(!ctx.flat_issue_path("o", "r", 1, "Parent Issue").exists(), "Old flat format file should be removed");
+	assert!(!ctx.flat_issue_path(repo(), 1, "Parent Issue").exists(), "Old flat format file should be removed");
 
 	// New directory format should exist
-	assert!(ctx.dir_issue_path("o", "r", 1, "Parent Issue").exists(), "Directory format file should be created");
+	assert!(ctx.dir_issue_path(repo(), 1, "Parent Issue").exists(), "Directory format file should be created");
 }
 
 #[test]
@@ -101,11 +105,11 @@ fn test_old_placement_discarded_with_pull() {
 	assert!(status.success(), "Should succeed. stderr: {stderr}");
 
 	// The critical assertion: old flat file must be gone
-	let flat_path = ctx.flat_issue_path("o", "r", 1, "Parent Issue");
+	let flat_path = ctx.flat_issue_path(repo(), 1, "Parent Issue");
 	assert!(!flat_path.exists(), "Old flat format file at {flat_path:?} should be removed when using --pull");
 
 	// New directory format should exist with the main file
-	let dir_path = ctx.dir_issue_path("o", "r", 1, "Parent Issue");
+	let dir_path = ctx.dir_issue_path(repo(), 1, "Parent Issue");
 	assert!(dir_path.exists(), "Directory format file at {dir_path:?} should be created");
 
 	// Sub-issue directory should exist
@@ -136,7 +140,7 @@ fn test_duplicate_removes_local_file() {
 
 	// Original file should be removed (duplicate self-eliminates)
 	assert!(
-		!ctx.flat_issue_path("o", "r", 1, "Some Issue").exists(),
+		!ctx.flat_issue_path(repo(), 1, "Some Issue").exists(),
 		"Issue file should be removed after marking as duplicate"
 	);
 }
@@ -169,7 +173,7 @@ fn test_duplicate_reference_to_existing_issue_succeeds() {
 
 	// Original file should be removed (duplicate handling)
 	assert!(
-		!ctx.flat_issue_path("o", "r", 1, "Some Issue").exists(),
+		!ctx.flat_issue_path(repo(), 1, "Some Issue").exists(),
 		"Issue file should be removed after successful duplicate marking"
 	);
 }


### PR DESCRIPTION
## Summary

- Replace all occurrences of `owner: &str, repo: &str` function parameters with a single `RepoInfo` struct parameter
- This improves API ergonomics and ensures owner/repo are always passed together consistently
- Affects core functions in `IssueIndex`, `Local`, conflict resolution, git consensus, sync, and test helpers

## Changes

- `IssueIndex::root()`, `repo_only()`, `with_index()` now take `RepoInfo`
- `Local` path methods (`project_dir`, `find_issue_file`, etc.) take `RepoInfo`
- `conflict.rs` and `consensus/git.rs` functions take `RepoInfo`
- `sync.rs` core functions take `RepoInfo`
- `MockGithubClient` test helpers take `RepoInfo` (`add_issue`, `add_comment`, etc.)
- Test helpers (`flat_issue_path`, `dir_issue_path`, `open_url`) take `RepoInfo`
- Added `From<RepoInfo> for RepoKey` in `mock_github.rs`

## Test plan

- [x] All 157 existing tests pass
- [x] Build succeeds

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)