### PR TITLE
refactor: replace (owner, repo) params with RepoInfo struct

### DIFF
--- a/src/local/conflict.rs
+++ b/src/local/conflict.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 use v_utils::prelude::*;
 
 use super::{Local, consensus::is_git_initialized};
-use crate::Issue;
+use crate::{Issue, RepoInfo};
 
 //==============================================================================
 // Error Types
@@ -134,10 +134,13 @@ pub enum ConflictOutcome {
 /// 3. Merging that branch (which may produce conflicts)
 ///
 /// Both local and remote are written to `{owner}/__conflict.md` in virtual format.
-pub fn initiate_conflict_merge(owner: &str, repo: &str, issue_number: u64, local_issue: &Issue, remote_issue: &Issue) -> Result<ConflictOutcome, ConflictError> {
+pub fn initiate_conflict_merge(repo_info: RepoInfo, issue_number: u64, local_issue: &Issue, remote_issue: &Issue) -> Result<ConflictOutcome, ConflictError> {
 	if !is_git_initialized() {
 		return Err(ConflictError::GitNotInitialized);
 	}
+
+	let owner = repo_info.owner();
+	let repo = repo_info.repo();
 
 	let data_dir = Local::issues_dir();
 	let data_dir_str = data_dir.to_str().ok_or_else(|| ConflictError::GitError {

--- a/src/open_interactions/command.rs
+++ b/src/open_interactions/command.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use clap::Args;
 use tedi::{
-	Issue, IssueIndex, IssueLink, IssueSelector, LazyIssue,
+	Issue, IssueIndex, IssueLink, IssueSelector, LazyIssue, RepoInfo,
 	local::{ExactMatchLevel, FsReader, Local, LocalIssueSource, LocalPath, Submitted},
 	sink::Sink,
 };
@@ -178,7 +178,7 @@ pub async fn open_command(settings: &LiveSettings, args: OpenArgs, offline: bool
 		let (owner, repo, issue_number) = github::parse_github_issue_url(input)?;
 
 		// Check if we already have this issue locally
-		let index = IssueIndex::root(&owner, &repo, IssueSelector::GitId(issue_number));
+		let index = IssueIndex::root(RepoInfo::new(&owner, &repo), IssueSelector::GitId(issue_number));
 		let existing_path = LocalPath::from(index)
 			.resolve_parent(FsReader)
 			.ok()

--- a/src/open_interactions/merge.rs
+++ b/src/open_interactions/merge.rs
@@ -197,14 +197,18 @@ fn merge_children(self_children: &mut Vec<Issue>, other_children: Vec<Issue>, fo
 
 #[cfg(test)]
 mod tests {
-	use tedi::{IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps};
+	use tedi::{IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps, RepoInfo};
 
 	use super::*;
+
+	fn test_repo() -> RepoInfo {
+		RepoInfo::new("test", "repo")
+	}
 
 	fn make_linked_issue(title: &str, number: u64, timestamps: IssueTimestamps) -> Issue {
 		let url = format!("https://github.com/test/repo/issues/{number}");
 		let link = IssueLink::parse(&url).unwrap();
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(test_repo());
 		let identity = IssueIdentity::linked(Some(parent_index), "user".to_string(), link, timestamps);
 		Issue {
 			identity,
@@ -220,7 +224,7 @@ mod tests {
 	}
 
 	fn make_pending_issue(title: &str) -> Issue {
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(test_repo());
 		let identity = IssueIdentity::pending(parent_index);
 		Issue {
 			identity,
@@ -237,7 +241,7 @@ mod tests {
 
 	#[test]
 	fn test_merge_virtual_error() {
-		let parent_index = IssueIndex::repo_only("test", "repo");
+		let parent_index = IssueIndex::repo_only(test_repo());
 		// Create a virtual issue (local-only, never synced to Github)
 		let mut virtual_issue = Issue {
 			identity: IssueIdentity::virtual_issue(parent_index),

--- a/src/open_interactions/remote/mod.rs
+++ b/src/open_interactions/remote/mod.rs
@@ -145,10 +145,10 @@ impl RemoteSource {
 		// Build parent_index with all parent numbers as GitId selectors
 		// Return None for root-level issues (empty lineage)
 		if lineage.is_empty() {
-			Ok(Some(IssueIndex::repo_only(repo_info.owner(), repo_info.repo())))
+			Ok(Some(IssueIndex::repo_only(repo_info)))
 		} else {
 			let selectors: Vec<IssueSelector> = lineage.iter().map(|&n| IssueSelector::GitId(n)).collect();
-			Ok(Some(IssueIndex::with_index(repo_info.owner(), repo_info.repo(), selectors)))
+			Ok(Some(IssueIndex::with_index(repo_info, selectors)))
 		}
 	}
 

--- a/src/open_interactions/touch.rs
+++ b/src/open_interactions/touch.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use regex::Regex;
 use tedi::{
-	Issue, IssueIndex, IssueSelector, LazyIssue,
+	Issue, IssueIndex, IssueSelector, LazyIssue, RepoInfo,
 	local::{FsReader, Local, LocalIssueSource},
 };
 use v_utils::prelude::*;
@@ -106,7 +106,7 @@ pub fn parse_touch_path(user_input: &str) -> Result<TouchPathResult> {
 					index.push(parent_selector);
 					let child_title = strip_md_extension(lineage_rgxs[i + 1]);
 					index.push(IssueSelector::title(child_title));
-					return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(&owner, &repo, index))));
+					return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(RepoInfo::new(&owner, &repo), index))));
 				}
 
 				matched_lineage.push(matched);
@@ -116,7 +116,7 @@ pub fn parse_touch_path(user_input: &str) -> Result<TouchPathResult> {
 				// No match - this is a create request
 				let mut index: Vec<IssueSelector> = matched_lineage.iter().filter_map(|s| Local::parse_issue_selector_from_name(s)).collect();
 				index.push(IssueSelector::title(pattern));
-				return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(&owner, &repo, index))));
+				return Ok(TouchPathResult::Create(Box::new(IssueIndex::with_index(RepoInfo::new(&owner, &repo), index))));
 			}
 			MatchOrNone::Ambiguous(matches) => {
 				let desc = if is_last { "issue" } else { "parent issue" };

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -188,10 +188,10 @@ pub trait Sink<S> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{BlockerSequence, CloseState, Events, IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps};
+	use crate::{BlockerSequence, CloseState, Events, IssueContents, IssueIdentity, IssueIndex, IssueLink, IssueTimestamps, RepoInfo};
 
 	fn make_issue(title: &str, number: Option<u64>) -> Issue {
-		let parent_index = IssueIndex::repo_only("o", "r");
+		let parent_index = IssueIndex::repo_only(RepoInfo::new("o", "r"));
 		let identity = match number {
 			Some(n) => {
 				let link = IssueLink::parse(&format!("https://github.com/o/r/issues/{n}")).unwrap();

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -116,8 +116,8 @@ impl TestContext {
 	}
 
 	/// Create an OpenBuilder for running the `open` command with a Github URL.
-	pub fn open_url(&self, owner: &str, repo: &str, number: u64) -> OpenBuilder<'_> {
-		let url = format!("https://github.com/{owner}/{repo}/issues/{number}");
+	pub fn open_url(&self, repo_info: tedi::RepoInfo, number: u64) -> OpenBuilder<'_> {
+		let url = format!("https://github.com/{}/{}/issues/{number}", repo_info.owner(), repo_info.repo());
 		OpenBuilder {
 			ctx: self,
 			target: BuilderTarget::Url(url),
@@ -349,12 +349,12 @@ pub mod are_you_sure {
 		/// Get the flat format path for an issue: `{number}_-_{title}.md`
 		///
 		/// **Unsafe**: bypasses proper issue addressing. Use only for filesystem tests.
-		fn flat_issue_path(&self, owner: &str, repo: &str, number: u64, title: &str) -> PathBuf;
+		fn flat_issue_path(&self, repo_info: tedi::RepoInfo, number: u64, title: &str) -> PathBuf;
 
 		/// Get the directory format path for an issue: `{number}_-_{title}/__main__.md`
 		///
 		/// **Unsafe**: bypasses proper issue addressing. Use only for filesystem tests.
-		fn dir_issue_path(&self, owner: &str, repo: &str, number: u64, title: &str) -> PathBuf;
+		fn dir_issue_path(&self, repo_info: tedi::RepoInfo, number: u64, title: &str) -> PathBuf;
 
 		/// Resolve an issue's actual filesystem path after it's been written.
 		///
@@ -363,14 +363,14 @@ pub mod are_you_sure {
 	}
 
 	impl UnsafePathExt for TestContext {
-		fn flat_issue_path(&self, owner: &str, repo: &str, number: u64, title: &str) -> PathBuf {
+		fn flat_issue_path(&self, repo_info: tedi::RepoInfo, number: u64, title: &str) -> PathBuf {
 			let sanitized = title.replace(' ', "_");
-			self.xdg.data_dir().join(format!("issues/{owner}/{repo}/{number}_-_{sanitized}.md"))
+			self.xdg.data_dir().join(format!("issues/{}/{}/{number}_-_{sanitized}.md", repo_info.owner(), repo_info.repo()))
 		}
 
-		fn dir_issue_path(&self, owner: &str, repo: &str, number: u64, title: &str) -> PathBuf {
+		fn dir_issue_path(&self, repo_info: tedi::RepoInfo, number: u64, title: &str) -> PathBuf {
 			let sanitized = title.replace(' ', "_");
-			self.xdg.data_dir().join(format!("issues/{owner}/{repo}/{number}_-_{sanitized}/__main__.md"))
+			self.xdg.data_dir().join(format!("issues/{}/{}/{number}_-_{sanitized}/__main__.md", repo_info.owner(), repo_info.repo()))
 		}
 
 		fn resolve_issue_path(&self, issue: &tedi::Issue) -> PathBuf {

--- a/tests/integration/file_naming.rs
+++ b/tests/integration/file_naming.rs
@@ -31,10 +31,10 @@ async fn test_flat_format_preserved_when_no_sub_issues() {
 	assert!(out.status.success(), "Should succeed. stderr: {}", out.stderr);
 
 	// Flat file should still exist
-	assert!(ctx.flat_issue_path("o", "r", 1, "Parent Issue").exists(), "Flat format file should still exist");
+	assert!(ctx.flat_issue_path(("o", "r").into(), 1, "Parent Issue").exists(), "Flat format file should still exist");
 
 	// Directory format should NOT exist
-	assert!(!ctx.dir_issue_path("o", "r", 1, "Parent Issue").exists(), "Directory format should not be created");
+	assert!(!ctx.dir_issue_path(("o", "r").into(), 1, "Parent Issue").exists(), "Directory format should not be created");
 }
 
 #[tokio::test]
@@ -65,10 +65,10 @@ async fn test_old_flat_file_removed_when_sub_issues_appear() {
 	assert!(out.status.success(), "Should succeed. stderr: {}", out.stderr);
 
 	// Old flat file should be removed
-	assert!(!ctx.flat_issue_path("o", "r", 1, "Parent Issue").exists(), "Old flat format file should be removed");
+	assert!(!ctx.flat_issue_path(("o", "r").into(), 1, "Parent Issue").exists(), "Old flat format file should be removed");
 
 	// New directory format should exist
-	assert!(ctx.dir_issue_path("o", "r", 1, "Parent Issue").exists(), "Directory format file should be created");
+	assert!(ctx.dir_issue_path(("o", "r").into(), 1, "Parent Issue").exists(), "Directory format file should be created");
 }
 
 #[tokio::test]
@@ -101,11 +101,11 @@ async fn test_old_placement_discarded_with_pull() {
 	assert!(out.status.success(), "Should succeed. stderr: {}", out.stderr);
 
 	// The critical assertion: old flat file must be gone
-	let flat_path = ctx.flat_issue_path("o", "r", 1, "Parent Issue");
+	let flat_path = ctx.flat_issue_path(("o", "r").into(), 1, "Parent Issue");
 	assert!(!flat_path.exists(), "Old flat format file at {flat_path:?} should be removed when using --pull");
 
 	// New directory format should exist with the main file
-	let dir_path = ctx.dir_issue_path("o", "r", 1, "Parent Issue");
+	let dir_path = ctx.dir_issue_path(("o", "r").into(), 1, "Parent Issue");
 	assert!(dir_path.exists(), "Directory format file at {dir_path:?} should be created");
 
 	// Sub-issue directory should exist
@@ -136,7 +136,7 @@ async fn test_duplicate_removes_local_file() {
 
 	// Original file should be removed (duplicate self-eliminates)
 	assert!(
-		!ctx.flat_issue_path("o", "r", 1, "Some Issue").exists(),
+		!ctx.flat_issue_path(("o", "r").into(), 1, "Some Issue").exists(),
 		"Issue file should be removed after marking as duplicate"
 	);
 }
@@ -169,7 +169,7 @@ async fn test_duplicate_reference_to_existing_issue_succeeds() {
 
 	// Original file should be removed (duplicate handling)
 	assert!(
-		!ctx.flat_issue_path("o", "r", 1, "Some Issue").exists(),
+		!ctx.flat_issue_path(("o", "r").into(), 1, "Some Issue").exists(),
 		"Issue file should be removed after successful duplicate marking"
 	);
 }

--- a/tests/integration/reset_conflict.rs
+++ b/tests/integration/reset_conflict.rs
@@ -38,7 +38,7 @@ fn test_reset_with_subissue_edit() {
 	);
 
 	// --reset fetches remote and establishes consensus, then user edits
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).edit(&edited).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).edit(&edited).run();
 
 	assert!(out.status.success(), "Should succeed. stderr: {}", out.stderr);
 	assert!(!out.stderr.contains("Conflict"), "No conflict expected. stderr: {}", out.stderr);
@@ -55,7 +55,7 @@ fn test_reset_with_body_edit() {
 
 	let edited = parse("- [ ] Test Issue <!-- @mock_user https://github.com/o/r/issues/1 -->\n\tmodified body\n");
 
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).edit(&edited).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).edit(&edited).run();
 
 	assert!(out.status.success(), "Should succeed. stderr: {}", out.stderr);
 	assert!(!out.stderr.contains("Conflict"), "No conflict expected. stderr: {}", out.stderr);
@@ -93,7 +93,7 @@ async fn test_reset_discards_local_subissue_modifications() {
 	ctx.remote(&remote_state, None);
 
 	// Step 1: Initial fetch to create local files
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 	assert!(out.status.success(), "Initial fetch failed. stderr: {}", out.stderr);
 
 	// Step 2: User modifies the parent sub-issue (adds blockers)
@@ -131,7 +131,7 @@ async fn test_reset_discards_local_subissue_modifications() {
 		 \t\t\tchild body\n",
 	);
 
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).edit(&edited_after_reset).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).edit(&edited_after_reset).run();
 
 	assert!(out.status.success(), "Edit after reset failed. stderr: {}", out.stderr);
 	assert!(!out.stderr.contains("Conflict"), "No conflict expected. stderr: {}", out.stderr);

--- a/tests/integration/sync.rs
+++ b/tests/integration/sync.rs
@@ -224,10 +224,10 @@ async fn test_url_open_creates_local_file_from_remote() {
 	ctx.remote(&remote, Some(Seed::new(15)));
 
 	// No local file exists - URL open should create it
-	let expected_path = ctx.flat_issue_path("o", "r", 1, "Test Issue");
+	let expected_path = ctx.flat_issue_path(("o", "r").into(), 1, "Test Issue");
 	assert!(!expected_path.exists(), "Local file should not exist before open");
 
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 
 	eprintln!("stdout: {}", out.stdout);
 	eprintln!("stderr: {}", out.stderr);
@@ -255,7 +255,7 @@ async fn test_reset_with_remote_url_nukes_local_state() {
 	ctx.remote(&remote, Some(Seed::new(80)));
 
 	// Open via URL with --reset should nuke local and use remote
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).run();
 
 	eprintln!("stdout: {}", out.stdout);
 	eprintln!("stderr: {}", out.stderr);
@@ -285,7 +285,7 @@ async fn test_reset_with_remote_url_skips_merge_on_divergence() {
 	ctx.remote(&remote, Some(Seed::new(35)));
 
 	// Open via URL with --reset should NOT trigger merge conflict
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).run();
 
 	eprintln!("stdout: {}", out.stdout);
 	eprintln!("stderr: {}", out.stderr);
@@ -442,7 +442,7 @@ async fn test_duplicate_sub_issues_filtered_from_remote() {
 	ctx.remote(&parent_with_children, Some(Seed::new(-10)));
 
 	// Open via URL to fetch from remote
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 
 	eprintln!("stdout: {}", out.stdout);
 	eprintln!("stderr: {}", out.stderr);
@@ -474,7 +474,7 @@ async fn test_open_unchanged_succeeds() {
 	ctx.remote(&issue, Some(Seed::new(10)));
 
 	// First open via URL
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 	assert!(out.status.success(), "First open should succeed. stderr: {}", out.stderr);
 
 	// Second open - should also succeed (no-op since nothing changed)
@@ -497,14 +497,14 @@ async fn test_open_by_number_unchanged_succeeds() {
 	ctx.remote(&issue, None);
 
 	// First open via URL with --reset
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).run();
 	eprintln!("First open stdout: {}", out.stdout);
 	eprintln!("First open stderr: {}", out.stderr);
 	assert!(out.status.success(), "First open should succeed. stderr: {}", out.stderr);
 
 	// Second open by number (simulating the failing case)
 	// This uses the mock, so remote state is the same
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 	eprintln!("Second open stdout: {}", out.stdout);
 	eprintln!("Second open stderr: {}", out.stderr);
 	assert!(out.status.success(), "Second open (unchanged) should succeed. stderr: {}", out.stderr);
@@ -523,7 +523,7 @@ async fn test_reset_syncs_changes_after_editor() {
 	// emulate user closing the issue after
 	let mut modified_issue = remote_issue.clone();
 	modified_issue.contents.state = tedi::CloseState::Closed;
-	let out = ctx.open_url("o", "r", 1).args(&["--reset"]).edit(&modified_issue).run();
+	let out = ctx.open_url(("o", "r").into(), 1).args(&["--reset"]).edit(&modified_issue).run();
 
 	insta::assert_snapshot!(render_fixture(FixtureRenderer::try_new(&ctx).unwrap().redact_timestamps(&[11]), &out), @r#"
 	//- /o/r/.meta.json
@@ -694,7 +694,7 @@ async fn test_consensus_sink_writes_meta_json_with_timestamps() {
 	ctx.remote(&remote, None);
 
 	// Fetch the issue via URL - this should sink to Consensus and write .meta.json
-	let out = ctx.open_url("o", "r", 1).run();
+	let out = ctx.open_url(("o", "r").into(), 1).run();
 
 	eprintln!("stdout: {}", out.stdout);
 	eprintln!("stderr: {}", out.stderr);


### PR DESCRIPTION
## Summary

- Replace all occurrences of `owner: &str, repo: &str` function parameters with the unified `RepoInfo` struct
- This improves API ergonomics and ensures owner/repo are always passed together consistently
- Added `From<(&str, &str)> for RepoInfo` for ergonomic test usage with `.into()`

## Changes

### Core types (src/issue/types.rs)
- `IssueIndex::root()`, `with_index()`, `repo_only()` now take `RepoInfo`
- Added `From<(&str, &str)> for RepoInfo`

### Local filesystem (src/local/)
- `Local::project_dir()`, `load_project_meta()`, `save_project_meta()` take `RepoInfo`
- `ensure_virtual_project()`, `allocate_virtual_issue_number()` take `RepoInfo`
- `save_issue_meta()`, `remove_issue_meta()` take `RepoInfo`
- `initiate_conflict_merge()` in conflict.rs takes `RepoInfo`

### Sync (src/open_interactions/)
- `core::resolve_merge()` takes `RepoInfo`
- Updated touch.rs, command.rs, remote/mod.rs to construct `RepoInfo`

### Test infrastructure
- `MockGithubClient` helpers (`add_issue`, `add_comment`, `add_sub_issue_relation`) take `RepoInfo`
- Added `From<RepoInfo> for RepoKey` in mock_github.rs
- Test helpers (`open_url`, `flat_issue_path`, `dir_issue_path`) take `RepoInfo`
- Tests use `("o", "r").into()` for ergonomic RepoInfo construction

## Test plan

- [x] All 46 integration tests pass
- [x] Build succeeds (lib + bins)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)